### PR TITLE
Enforce 0.0 * inf = 0.0

### DIFF
--- a/geomloss/utils.py
+++ b/geomloss/utils.py
@@ -9,6 +9,10 @@ except:
 
 
 def scal(α, f, batch=False):
+    # f can become inf which would produce NaNs later on. Here we basically
+    # enforce 0.0 * inf = 0.0.
+    f = torch.where(α == 0.0, f.new_full((), 0.0), f)
+
     if batch:
         B = α.shape[0]
         return (α.view(B, -1) * f.view(B, -1)).sum(1)


### PR DESCRIPTION
In unbalanced OT with small `reach`, `f` can become `inf` in some cases which should not matter because it is multiplied by 0 (`alpha` is 0 in the cases where `f` is inf in my experience). But without this fix, we multiply `0.0 * inf` which is NaN in floating point numbers instead of 0.