### PR TITLE
Fixed "ValueError" in epsilon_schedule() when computing 0 sinkhorn distance.

### DIFF
--- a/geomloss/sinkhorn_divergence.py
+++ b/geomloss/sinkhorn_divergence.py
@@ -157,6 +157,9 @@ def scaling_parameters(x, y, p, blur, reach, diameter, scaling):
     if diameter is None:
         D = x.shape[-1]
         diameter = max_diameter(x.view(-1, D), y.view(-1, D))
+    
+    # small diameter np.log() in epsilon_schedule() cannot be 0.
+    diameter = max(diameter, blur)
 
     eps = blur ** p
     rho = None if reach is None else reach ** p


### PR DESCRIPTION
fixed #34, #51, #74.

# Cause
The roughly estimated maximum diameter is 0. By default, **diameter** of `geomloss.SamplesLoss` is `None`, an upper bound of the distance will be roughly estimated and used for generating the epsilon list. When the inputs are too close or the same, the estimated maximum diameter could be 0. Then `p * np.log(diameter)* `raises *ValueError: Maximum allowed size exceeded* for **np.log(0)** is **-inf**.

# Solution
Set the argument **blur** as a lower bound for diameter. This still provides a valid eps_list for the further process.

# Results
Using the case in #51 
![image](https://github.com/jeanfeydy/geomloss/assets/72877707/57d031ff-17f4-4b28-831c-bf06abc37d08)
